### PR TITLE
Fix subpath in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,10 +13,10 @@
       "sizes": "512x512"
     }
   ],
-  "start_url": "/",
+  "start_url": "/map",
   "background_color": "#0f3d4c",
   "display": "standalone",
-  "scope": "/",
+  "scope": "/map",
   "theme_color": "#0f3d4c",
 
   "version": "1.2"


### PR DESCRIPTION
When adding the map to the home screen (tested on Android), tapping the tile launches https://york.ac.uk, not the map. This PR sets the `start_url` of the manifest properly. It also sets the navigation scope, so going to pages outside the map will open the default browser.